### PR TITLE
Add cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required (VERSION 3.0.2)
+project (JIGSAW)
+
+include_directories ("${PROJECT_SOURCE_DIR}/inc")
+
+add_subdirectory (src)
+
+add_subdirectory (uni)
+
+install (TARGETS jigsaw-bin tripod DESTINATION bin)
+install (DIRECTORY inc/ DESTINATION include FILES_MATCHING PATTERN "*.h")
+install (TARGETS jigsaw DESTINATION lib)
+
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable (jigsaw-bin jigsaw.cpp)
+target_compile_definitions (jigsaw-bin PRIVATE NDEBUG __cmd_jigsaw)
+set_target_properties (jigsaw-bin PROPERTIES OUTPUT_NAME jigsaw)
+
+add_executable (tripod jigsaw.cpp)
+target_compile_definitions (tripod PRIVATE NDEBUG __cmd_tripod)
+
+add_library (jigsaw SHARED jigsaw.cpp)
+target_compile_definitions (jigsaw PRIVATE NDEBUG __lib_jigsaw)

--- a/uni/CMakeLists.txt
+++ b/uni/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable (test_1 test_1.c)
+target_link_libraries (test_1 jigsaw)
+
+add_executable (test_2 test_2.c)
+target_link_libraries (test_2 jigsaw)
+
+add_executable (test_3 test_3.c)
+target_link_libraries (test_3 jigsaw)
+
+add_executable (test_4 test_4.c)
+target_link_libraries (test_4 jigsaw)
+
+add_executable (test_5 test_5.c)
+target_link_libraries (test_5 jigsaw)
+
+


### PR DESCRIPTION
Three files are added that allow users to build `jigsaw`, `tripod`, `libjigsaw` and the unit tests.  A typical workflow would be:

```bash
# build and install JIGSAW
mkdir build
cd build
cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release ..
make
make install

# make sure jigsaw is working
cd ..
jigsaw example.jig
```

To run the unit tests, one would do:
```bash
cd build/uni
for test in 1 2 3 4 5
do
  ./test_${test}
done
```